### PR TITLE
Upgrade Bundler to version 2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,4 +33,4 @@ DEPENDENCIES
   statsd-ruby
 
 BUNDLED WITH
-   1.15.1
+   2.4.7


### PR DESCRIPTION
This was missed in https://github.com/alphagov/govuk-sentry-monitor/pull/9

Trello card: https://trello.com/c/e5BZBWyK/3075-bump-platform-reliability-repos-ruby-versions-to-v3xx-5