### PR TITLE
Update Nokogiri to v 1.14.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,7 @@ GEM
     mini_portile2 (2.8.1)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
-    nokogiri (1.13.10)
+    nokogiri (1.14.2)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     racc (1.6.2)


### PR DESCRIPTION
The current version `1.13.10` is incompatible with Ruby version 3.2

Related PRs: https://github.com/alphagov/govuk-sentry-monitor/pull/9 https://github.com/alphagov/govuk-sentry-monitor/pull/11

Trello card: https://trello.com/c/e5BZBWyK/3075-bump-platform-reliability-repos-ruby-versions-to-v3xx-5